### PR TITLE
Added debug log checking for PPS synchronisation

### DIFF
--- a/src/rs_driver/driver/decoder/decoder_RS16.hpp
+++ b/src/rs_driver/driver/decoder/decoder_RS16.hpp
@@ -214,6 +214,20 @@ inline RSDecoderResult DecoderRS16<T_Point>::decodeDifopPkt(const uint8_t* pkt)
   {
     return RSDecoderResult::WRONG_PKT_HEADER;
   }
+
+  // check for PPS UTC synchronisation
+  if (dpkt_ptr->diagno.gps_status & 1) {
+    printf("Warning: PPS lock is invalid!\n");
+  }
+  if (dpkt_ptr->diagno.gps_status & 2) {
+    printf("Warning: GPRMC is invalid!\n");
+  }
+  if ((dpkt_ptr->diagno.gps_status & 4) == 0) {
+    printf("Warning: LiDAR internal timestamp is not synchronizing the UTC!\n");
+  } else {
+    printf("LiDAR internal timestamp is synchronizing UTC!\n");
+  }
+
   this->template decodeDifopCommon<RS16DifopPkt>(pkt, LidarType::RS16);
   if (!this->difop_flag_)
   {


### PR DESCRIPTION
Reading PPS and UTC bit from DIFOP packet generated by RS16 Lidar as documented on page 48 of [manual](https://www.robotshop.com/media/files/content/r/rse/pdf/robosense-rs-lidar-16-laser-rangefinder-150-m-user-guide.pdf).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/orcamobility/rs_driver/2)
<!-- Reviewable:end -->
